### PR TITLE
[no-unused-vars]: Disallow declaration of variables that are not used in the code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ module.exports = {
     'no-undef': 2,
     'no-underscore-dangle': 0,
     'no-unused-expressions': 0,
-    'no-unused-vars': 0,
+    // Disallow declaration of variables that are not used in the code.
+    'no-unused-vars': [2, { vars: 'local' }],
     'no-use-before-define': [ 2, 'nofunc' ],
     'no-with': 2,
     'one-var': [ 2, 'never' ],


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/7609

Relevant rule: http://eslint.org/docs/rules/no-unused-vars

There are 1070 instances of unused vars in Kibana, according to this rule. Let's kill 'em!
